### PR TITLE
List required packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
 	# repository. For example: MIT 
 	license='MIT',
 	# Short description of your library 
-	description='Python library for argument and configuration management ',
+	description='Python library for argument and configuration management',
 	# Long description of your library 
 	long_description=long_description,
 	long_description_content_type='text/markdown',
@@ -38,7 +38,10 @@ setup(
 	# List of keywords 
 	keywords=['parameters', 'configuration', 'decorators'],
 	# List of packages to install with this one 
-	install_requires=[],
+	install_requires=[
+		'pyyaml',
+		'terminaltables'
+	],
 	# https://pypi.org/classifiers/ 
 	classifiers=['Development Status :: 5 - Production/Stable', 'Environment :: Console']
 )


### PR DESCRIPTION
This fixes #14, by restoring the install_requires field which got lost when moving back to setup.py. I also deleted a superfluous space in the short description.

pyyaml _could_ be an [optional dependency](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies) perhaps.