### PR TITLE
added as_dict method to Config

### DIFF
--- a/fastargs/config.py
+++ b/fastargs/config.py
@@ -21,6 +21,7 @@ class Config:
         self.entries = {}
         self.content = {}
 
+
     def add_section(self, section):
         self.sections[section.ns] = section
 
@@ -239,3 +240,14 @@ or from CLI arguments. For CLI just use:
 
         return self
 
+    def as_dict(self):
+        """ Stores config in a dict, like 'section.parameter' -> value """
+        output = {}
+        for path in self.entries.keys():
+            try:
+                value = self[path]
+                if value is not None:
+                    output['.'.join(path)] =  self[path]
+            except:
+                pass
+        return output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -114,6 +114,24 @@ class TestStringMethods(unittest.TestCase):
         self.assertIn('3', output)
         self.assertNotIn('first.sec.param3', output)
 
+    def test_as_dict(self):
+        Section('first_sec', 'test_sec1').params(
+            param1=Param(Anything(), required=True),
+            param2=Param(Anything(), default='3'),
+            param3=Param(Anything(), required=False)
+        )
+
+        cfg = get_current_config().collect({
+            'first_sec.param1': 42
+            })
+
+        output_dict = cfg.as_dict()
+        target = {'first_sec.param1': 42,
+                  'first_sec.param2': '3'}
+
+        self.assertDictEqual(output_dict, target)
+
+
     def test_conditional_arguments(self):
         Section('a').params(
             value=Param(int)


### PR DESCRIPTION
Found it helpful to throw config object to my logger. This is easier when I can stash the configs as a dict. Added tests, too.