### PR TITLE
Fix conditional sections failing when using command line arguments

### DIFF
--- a/fastargs/config.py
+++ b/fastargs/config.py
@@ -77,8 +77,6 @@ or from CLI arguments. For CLI just use:
                 table_content = [['Name', 'Default', 'Constraint', 'Description']]
                 for path in entries:
                     param = self.entries[path]
-                    if not param.section.is_enabled(self):
-                        continue
                     argname = '.'.join(path)
                     # We do not want to show the args since we have our nice table after
                     if argname == 'help' or argname == 'h':


### PR DESCRIPTION
Fixes bug when arguments are given with command line arguments when conditional sections are enabled.

When `param.section.is_enabled` is being checked in `config.augment_argparse()` the sections have not yet been initialized and so all the conditional sections will fail the check even if the conditions are true, when the parameters are passed through command line arguments. Check for conditional section is already being done in `config.__getitem__()` when `config.collect()` is called. So no need to check it in `config.augment_argparse()`.